### PR TITLE
AB#348 Change to dedicated host ports in docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 .*
 *.yml
-appsettings.*.json
+appsettings*.json
 
 bin
 obj

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
 
-WORKDIR /usr/local/team07/tokengram/backend
+WORKDIR /app
 
-COPY --link . .
+COPY --link . ./
 ENV HUSKY=0
 
 RUN dotnet restore
@@ -11,8 +11,8 @@ RUN dotnet publish -c Release --property:PublishDir=out
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0
 
-WORKDIR /usr/local/team07/tokengram/backend
-COPY --from=build-env /usr/local/team07/tokengram/backend/out .
+WORKDIR /app
+COPY --link --from=build-env /app/out ./
 
 ENV ASPNETCORE_URLS=http://+:5000
 EXPOSE 5000

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
+
+WORKDIR /app
+
+COPY --link . ./
+
+ENV HUSKY=0
+ENV ASPNETCORE_ENVIRONMENT=Development
+
+RUN dotnet tool install -g dotnet-ef --version 7.0.18
+RUN dotnet dev-certs https
+
+ENV PATH="${PATH}:/root/.dotnet/tools"
+
+RUN dotnet restore
+
+ENV ASPNETCORE_URLS=http://+:5000
+EXPOSE 5000
+
+ENTRYPOINT ["dotnet", "run", "--urls=http://+:5000"]

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -2,7 +2,7 @@ services:
   backend-db:
     image: postgres:alpine
     ports:
-      - 5432:5432
+      - ${TOKENGRAM_DB_HOST_PORT:-5010}:5432
     networks:
       - tokengram
     environment:
@@ -13,7 +13,7 @@ services:
     container_name: tokengram-backend
     image: tokengram-backend
     ports:
-      - 5000:5000
+      - ${TOKENGRAM_BACKEND_HOST_PORT:-5000}:5000
     environment:
       ASPNETCORE_ENVIRONMENT: Development
     volumes:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -7,9 +7,18 @@ services:
       - tokengram
     environment:
       POSTGRES_PASSWORD: tokengram
+    volumes:
+      - tokengram-backend_db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 1s
+      retries: 5
 
   backend:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.local
     container_name: tokengram-backend
     image: tokengram-backend
     ports:
@@ -19,12 +28,17 @@ services:
     volumes:
       - tokengram-backend_keys:/etc/team07/tokengram/backend/data-protection-keys
       - tokengram-backend_uploads:/var/tokengram/uploads/public
+      - ./appsettings.json:/app/appsettings.json:ro
+      - ./appsettings.Development.json:/app/appsettings.Development.json:ro
     networks:
       - tokengram
     depends_on:
-      - backend-db
+      backend-db:
+        condition: service_healthy
 
 volumes:
+  tokengram-backend_db:
+    name: tokengram-backend_db
   tokengram-backend_keys:
     name: tokengram-backend_keys
   tokengram-backend_uploads:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: tokengram-backend
     restart: unless-stopped
     ports:
-      - 5001:5000
+      - ${TOKENGRAM_BACKEND_HOST_PORT:-5000}:5000
     networks:
       - team07
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       - team07
     volumes:
       - tokengram-backend_keys:/etc/team07/tokengram/backend/data-protection-keys
-      - "../storage/uploads/public:/var/tokengram/uploads/public"
+      - ../storage/uploads/public:/var/tokengram/uploads/public
+      - ./appsettings.json:/app/appsettings.json:ro
 
 volumes:
   tokengram-backend_keys:

--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -6,26 +6,30 @@ if (-not $command)  {
     $command = "local"
 }
 
+$Context = "TokengramDbContext"
+$BackendContainer = "backend"
 $ProjectRoot = "${PSScriptRoot}/.."
+$ContainerProjectRoot = "/app"
+$LocalDockerCompose = "docker-compose.local.yml"
 
 switch ($command) {
     "db" {
-        dotnet ef database drop --project ${ProjectRoot} --context TokengramDbContext --force; dotnet ef database update --project ${ProjectRoot} --context TokengramDbContext
+        docker compose -f ${ProjectRoot}/${LocalDockerCompose} exec ${BackendContainer} bash -c "dotnet ef database drop --project ${ContainerProjectRoot} --context ${Context} --force; dotnet ef database update --project ${ContainerProjectRoot} --context ${Context}"
     }
     "db:setup" {
-        dotnet ef database update --project ${ProjectRoot} --context TokengramDbContext
+        docker compose -f ${ProjectRoot}/${LocalDockerCompose} exec ${BackendContainer} bash -c "dotnet ef database update --project ${ContainerProjectRoot} --context ${Context}"
     }
     "db:reset" {
-        dotnet ef database drop --project ${ProjectRoot} --context TokengramDbContext --force
+        docker compose -f ${ProjectRoot}/${LocalDockerCompose} exec ${BackendContainer} bash -c "dotnet ef database drop --project ${ContainerProjectRoot} --context ${Context} --force"
     }
     "local" {
-        docker compose -f ${ProjectRoot}/docker-compose-local.yml down; docker compose -f ${ProjectRoot}/docker-compose-local.yml up --build
+        docker compose -f ${ProjectRoot}/${LocalDockerCompose} down; docker compose -f ${ProjectRoot}/${LocalDockerCompose} up --build
     }
     "local:up" {
-        docker compose -f ${ProjectRoot}/docker-compose-local.yml up --build
+        docker compose -f ${ProjectRoot}/${LocalDockerCompose} up --build
     }
     "local:down" {
-        docker compose -f ${ProjectRoot}/docker-compose-local.yml down
+        docker compose -f ${ProjectRoot}/${LocalDockerCompose} down
     }
     default {
         throw "Unknown command: $command"


### PR DESCRIPTION
Adds separate Dockerfile for local development docker compose, modifies run script to run database migrations in docker instead of host (no need to have installed `dotnet-ef` on host from now on) and mounts appsettings instead of copying.